### PR TITLE
add BLE connection type

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2015-2016 Jeff Hoefs. All rights reserved.
+  Copyright (c) 2015-2017 Jeff Hoefs. All rights reserved.
 
   See file LICENSE-MIT for further informations on licensing terms.
 */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firmatabuilder.com",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Firmata Builder web application",
   "main": "app.js",
   "private": true,
@@ -13,7 +13,7 @@
     "cookie-parser": "~1.3.3",
     "debug": "~2.1.1",
     "express": "~4.11.0",
-    "firmata-builder": "^0.3.0",
+    "firmata-builder": "^0.4.0",
     "hbs": "~4.0.0",
     "lodash": "^3.9.1",
     "morgan": "~1.5.1",

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -6,6 +6,7 @@ $(function () {
   var $submitBtn = $('#submit');
   var $connectionType = $('#connectionType');
   var $serialConfig = $('#serialConfig');
+  var $bleConfig = $('#bleConfig');
   var $ethernetConfig = $('#ethernetConfig');
   var $wifiConfig = $('#wifiConfig');
   var $macAddress = $('#macAddress');
@@ -111,17 +112,26 @@ $(function () {
     case "serial":
       $ethernetConfig.hide();
       $wifiConfig.hide();
+      $bleConfig.hide();
       $serialConfig.show();
       break;
     case "ethernet":
       $serialConfig.hide();
       $wifiConfig.hide();
+      $bleConfig.hide();
       $ethernetConfig.show();
       break;
     case "wifi":
       $serialConfig.hide();
       $ethernetConfig.hide();
+      $bleConfig.hide();
       $wifiConfig.show();
+      break;
+    case "ble":
+      $serialConfig.hide();
+      $ethernetConfig.hide();
+      $wifiConfig.hide();
+      $bleConfig.show();
       break;
     }
     connectionType = val;

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -36,6 +36,10 @@ body {
   display: none;
 }
 
+#bleConfig {
+  display: none;
+}
+
 #uipEthernet {
   display: none;
 }
@@ -45,7 +49,7 @@ body {
 }
 
 #gatewayIp {
-  display:none;
+  display: none;
 }
 
 #configError {
@@ -72,5 +76,4 @@ body {
   .btn {
     margin-left: -15px;
   }
-
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2015-2016 Jeff Hoefs. All rights reserved.
+  Copyright (c) 2015-2017 Jeff Hoefs. All rights reserved.
 
   See file LICENSE-MIT for further informations on licensing terms.
 */
@@ -78,6 +78,15 @@ var parseConnection = function (data) {
         gatewayIp: connection.gatewayIp,
         ssid: connection.ssid,
         securityType: getWiFiSecurityType(connection)
+      }
+    }
+  } else if (connection.connectionType === "ble") {
+    return {
+      ble: {
+        controller: connection.bleController,
+        localName: connection.bleLocalName,
+        minInterval: connection.bleMinInterval,
+        maxInterval: connection.bleMaxInterval
       }
     }
   }

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -11,7 +11,7 @@
 
   <p>Make sure you first have the latest version of <a target="_blank" href="https://github.com/firmata/ConfigurableFirmata">ConfigurableFirmata</a> installed in your sketchbook libraries folder (typically <code>/Documents/Arduino/libraries/</code> for Mac or Linux or <code>\My Documents\Arduino\libraries\</code> for Windows). The latest version is <a href="{{this.version.url}}">{{this.version.tag}}</a>.</p>
 
-  <p>Next, select how you will connect to your client application. Typically this is a Serial connection at 57600 baud, but Wi-Fi and Ethernet are also available for certain boards and shields. BLE will be added in the future.</p>
+  <p>Next, select how you will connect to your client application. Typically this is a Serial connection at 57600 baud, but Wi-Fi, Ethernet and BLE are also available for certain boards and shields.</p>
 
   <p>Once you have the connection type configured, select the core features and any contributed features your application requires.</p>
 
@@ -32,6 +32,7 @@
             <option value="serial">Serial</option>
             <option value="wifi">Wi-Fi</option>
             <option value="ethernet">Ethernet</option>
+            <option value="ble">BLE</option>
           </select>
         </div>
       </div>
@@ -43,6 +44,8 @@
         {{> ethernet}}
 
         {{> wifi}}
+
+        {{> ble}}
 
         <div class="row">
           <div id="configError" class="col-sm-12">

--- a/views/partials/ble.hbs
+++ b/views/partials/ble.hbs
@@ -1,0 +1,48 @@
+<div id="bleConfig">
+  <div class="row">
+    <div class="col-sm-6">
+      <div class="form-group">
+        <label for="bleController">BLE board</label>
+        <select name="bleController" class="controller form-control">
+          {{#each controllers.ble}}
+          <option value="{{@key}}">{{this.name}}</option>
+          {{/each}}
+        </select>
+      </div>
+    </div>
+
+    <div class="col-sm-6">
+      <div class="form-group">
+        <label for="bleLocalName">Advertised local name</label>
+        <a href="#" tabindex="-1" data-toggle="tooltip" data-placement="top" title data-original-title="The local name the peripheral advertises to identify this board. If using multiple boards, set a unique local name for each board."> (?)</a>
+        <input type="text" class="form-control" name="bleLocalName" value="FIRMATA">
+      </div>
+    </div>
+  </div> <!-- end row 1 -->
+
+  <div class="row">
+    <div class="col-sm-5">
+      <div class="form-group">
+        <label class="control-label" for="bleMinInterval">Min connection interval</label>
+        <a href="#" tabindex="-1" data-toggle="tooltip" data-placement="top" title data-original-title="The value is the time in milliseconds divided by 1.25, so for an interval of 7.5ms, enter a value of 6 (7.5 / 1.25 = 6). A value of 6 (7.5ms) is the absolute minimum value supported. 6 is the default value. Search 'BLE connection interval' for more info."> (?)</a>
+        <input type="number" class="form-control" id="bleMinInterval" name="bleMinInterval" min="6" max="3200" value="6">
+      </div>
+    </div>
+
+    <div class="col-sm-5">
+      <div class="form-group">
+        <label class="control-label" for="bleMaxInterval">Max connection interval</label>
+        <a href="#" tabindex="-1" data-toggle="tooltip" data-placement="top" title data-original-title="The value is the time in milliseconds divided by 1.25 (30ms / 1.25 = 24). This value cannot be smaller than 6 or larger than 3200. 24 is the default value. Search 'BLE connection interval' for more info."> (?)</a>
+        <input type="number" class="form-control" id="bleMaxInterval" name="bleMaxInterval" min="6" max="3200" value="24">
+      </div>
+    </div>
+  </div> <!-- end row 2 -->
+
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="alert alert-warning fb-issues" role="alert"><small>
+        RedBearLab BLE Nano support requires patching the RedBearLab nRF51822-Arduino core library. See steps 1 - 3 in <a href="https://gist.github.com/soundanalogous/d39bb3eb36333a0906df">this gist</a> for instructions.</small>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Adds BLE as a connection type option. Currently only supports Arduino 101 out of box, and RedBearLab BLE Nano with a patch to the RBL core library.